### PR TITLE
Add arguments to generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,27 @@
-# generator-csc160-program [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
+# generator=cpp-csc [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
 > Scaffolds a project based on specifications in FRCC&#39;s CSC160 course
 
 ## Installation
 
-First, install [Yeoman](http://yeoman.io) and generator-csc160-program using [yarn](https://www.yarnpkg.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
+First, install [Yeoman](http://yeoman.io) and generator=cpp-csc using [yarn](https://www.yarnpkg.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
 
 ```bash
 yarn global add yo
-yarn global add generator-csc160-program
+yarn global add generator-cpp-csc
 ```
 
-Then generate your new project:
+Then generate your new project
+`MODULE_NUMBER` is the module you are in.
+`CHAPTER_NUMBER` is the chapter you are in.
+Both are required.
 
 ```bash
 mkdir <my-project>
 cd <my-project>
-yo csc-160-program .
+yo cpp-csc <MODULE_NUMBER> <CHAPTER_NUMBER>
 ```
 
-## Getting To Know Yeoman
-
- * Yeoman has a heart of gold.
- * Yeoman is a person with feelings and opinions, but is very easy to work with.
- * Yeoman can be too opinionated at times but is easily convinced not to be.
- * Feel free to [learn more about Yeoman](http://yeoman.io/).
+Feel free to [learn more about Yeoman](http://yeoman.io/).
 
 ## License
 
@@ -32,9 +30,9 @@ MIT © [Ashton Hellwig](https://github.com/ashellwig)
 
 [npm-image]: https://badge.fury.io/js/generator-cpp-csc.svg
 [npm-url]: https://npmjs.org/package/generator-cpp-csc
-[travis-image]: https://travis-ci.org/ashellwig/generator-csc160-program.svg?branch=master
-[travis-url]: https://travis-ci.org/ashellwig/generator-csc160-program
-[daviddm-image]: https://david-dm.org/ashellwig/generator-csc160-program.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/ashellwig/generator-csc160-program
-[coveralls-image]: https://coveralls.io/repos/ashellwig/generator-csc160-program/badge.svg
-[coveralls-url]: https://coveralls.io/r/ashellwig/generator-csc160-program
+[travis-image]: https://travis-ci.org/ashellwig/generator=cpp-csc.svg?branch=master
+[travis-url]: https://travis-ci.org/ashellwig/generator=cpp-csc
+[daviddm-image]: https://david-dm.org/ashellwig/generator=cpp-csc.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/ashellwig/generator=cpp-csc
+[coveralls-image]: https://coveralls.io/repos/ashellwig/generator=cpp-csc/badge.svg
+[coveralls-url]: https://coveralls.io/r/ashellwig/generator=cpp-csc

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# generator=cpp-csc [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
+# generator-cpp-csc [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage percentage][coveralls-image]][coveralls-url]
 > Scaffolds a project based on specifications in FRCC&#39;s CSC160 course
 
 ## Installation
 
-First, install [Yeoman](http://yeoman.io) and generator=cpp-csc using [yarn](https://www.yarnpkg.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
+First, install [Yeoman](http://yeoman.io) and generator-cpp-csc using [yarn](https://www.yarnpkg.com/) (we assume you have pre-installed [node.js](https://nodejs.org/)).
 
 ```bash
 yarn global add yo
@@ -30,9 +30,9 @@ MIT © [Ashton Hellwig](https://github.com/ashellwig)
 
 [npm-image]: https://badge.fury.io/js/generator-cpp-csc.svg
 [npm-url]: https://npmjs.org/package/generator-cpp-csc
-[travis-image]: https://travis-ci.org/ashellwig/generator=cpp-csc.svg?branch=master
-[travis-url]: https://travis-ci.org/ashellwig/generator=cpp-csc
-[daviddm-image]: https://david-dm.org/ashellwig/generator=cpp-csc.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/ashellwig/generator=cpp-csc
-[coveralls-image]: https://coveralls.io/repos/ashellwig/generator=cpp-csc/badge.svg
-[coveralls-url]: https://coveralls.io/r/ashellwig/generator=cpp-csc
+[travis-image]: https://travis-ci.org/ashellwig/generator-cpp-csc.svg?branch=master
+[travis-url]: https://travis-ci.org/ashellwig/generator-cpp-csc
+[daviddm-image]: https://david-dm.org/ashellwig/generator-cpp-csc.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/ashellwig/generator-cpp-csc
+[coveralls-image]: https://coveralls.io/repos/ashellwig/generator-cpp-csc/badge.svg
+[coveralls-url]: https://coveralls.io/r/ashellwig/generator-cpp-csc

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -10,18 +10,21 @@ module.exports = class extends Generator {
       yosay(`Welcome to the ${chalk.red('generator-csc160-program')} generator!`)
     )
 
-    // this.answers = await this.prompt([
-    //   {
-    //     type: 'input',
-    //     name: 'moduleNumber',
-    //     message: 'which module are we working on?'
-    //   },
-    //   {
-    //     type: 'input',
-    //     name: 'chapterNumber',
-    //     message: 'which chapter are we working on?'
-    //   }
-    // ])
+    const answers = await this.prompt([{
+      type: 'input',
+      name: 'modnum',
+      message: 'Which module are we in?'
+    }, {
+      type: 'input',
+      name: 'chapnum',
+      message: 'Which chapter are we in?'
+    }]).then(props => {
+      this.props.modnum = props.modnum
+      this.props.chapnum = props.chapnum
+    })
+
+    this.log('Module number', answers.modnum)
+    this.log('Chapter number', answers.chapnum)
   }
 
   writing () {
@@ -110,5 +113,16 @@ module.exports = class extends Generator {
     this.log('Please check Makefile and doc/assigned/main.tex for any \'TODO\' marks.')
     this.log('Wherever you find these, enter the chapter/module number where applicable.')
     this.log('On UNIX, simply using the command `sed -i \'s/TODO:/<number>/g\' Makefile` should suffice.')
+  }
+
+  install () {
+    this.spawnCommand('sed', ['-i', 's/TODO:MODNUM/' + this.props.modnum + '/g', 'Makefile'])
+    this.spawnCommand('sed', ['-i', 's/TODO:MODNUM/' + this.props.modnum + '/g', 'doc/assigned/main.tex'])
+    this.spawnCommand('sed', ['-i', 's/TODO:CHAPNUM/' + this.props.chapnum + '/g', 'Makefile'])
+    this.spawnCommand('sed', ['-i', 's/TODO:CHAPNUM/' + this.props.chapnum + '/g', 'doc/assigned/main.tex'])
+    this.log('Replaced placeholders with:')
+    this.log('Module number: ', this.props.chapnum)
+    this.log('Chapter number: ', this.props.modnum)
+    this.log('Enjoy!')
   }
 }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -4,27 +4,31 @@ const chalk = require('chalk')
 const yosay = require('yosay')
 
 module.exports = class extends Generator {
-  async prompting () {
+  prompting () {
     // Have Yeoman greet the user.
     this.log(
       yosay(`Welcome to the ${chalk.red('generator-csc160-program')} generator!`)
     )
 
-    const answers = await this.prompt([{
-      type: 'input',
-      name: 'modnum',
-      message: 'Which module are we in?'
-    }, {
-      type: 'input',
-      name: 'chapnum',
-      message: 'Which chapter are we in?'
-    }]).then(props => {
-      this.props.modnum = props.modnum
-      this.props.chapnum = props.chapnum
-    })
+    // const answers = this.prompt([{
+    //   type: 'input',
+    //   name: 'modnum',
+    //   message: 'Which module are we in?'
+    // }, {
+    //   type: 'input',
+    //   name: 'chapnum',
+    //   message: 'Which chapter are we in?'
+    // }])
 
-    this.log('Module number', answers.modnum)
-    this.log('Chapter number', answers.chapnum)
+    // this.log('Module number', answers.modnum)
+    // this.log('Chapter number', answers.chapnum)
+    // return answers
+  }
+
+  constructor (args, opts) {
+    super(args, opts)
+    this.argument('modnum', { type: String, required: true })
+    this.argument('chapnum', { type: String, required: true })
   }
 
   writing () {
@@ -32,19 +36,11 @@ module.exports = class extends Generator {
     this.fs.copy(
       this.templatePath('doc/assigned/main.tex'),
       this.destinationPath('doc/assigned/main.tex')
-      // [
-      //   { moduleNumber: this.prompts.moduleNumber },
-      //   { chapterNumber: this.prompts.chapterNumber }
-      // ]
     )
     // Makefile
     this.fs.copy(
       this.templatePath('Makefile'),
       this.destinationPath('Makefile')
-      // [
-      //   { moduleNumber: this.prompts.moduleNumber },
-      //   { chapterNumber: this.prompts.chapterNumber }
-      // ]
     )
     // src
     this.fs.copy(
@@ -109,20 +105,11 @@ module.exports = class extends Generator {
     )
   }
 
-  todos () {
-    this.log('Please check Makefile and doc/assigned/main.tex for any \'TODO\' marks.')
-    this.log('Wherever you find these, enter the chapter/module number where applicable.')
-    this.log('On UNIX, simply using the command `sed -i \'s/TODO:/<number>/g\' Makefile` should suffice.')
-  }
-
   install () {
-    this.spawnCommand('sed', ['-i', 's/TODO:MODNUM/' + this.props.modnum + '/g', 'Makefile'])
-    this.spawnCommand('sed', ['-i', 's/TODO:MODNUM/' + this.props.modnum + '/g', 'doc/assigned/main.tex'])
-    this.spawnCommand('sed', ['-i', 's/TODO:CHAPNUM/' + this.props.chapnum + '/g', 'Makefile'])
-    this.spawnCommand('sed', ['-i', 's/TODO:CHAPNUM/' + this.props.chapnum + '/g', 'doc/assigned/main.tex'])
-    this.log('Replaced placeholders with:')
-    this.log('Module number: ', this.props.chapnum)
-    this.log('Chapter number: ', this.props.modnum)
+    this.spawnCommand('sed', ['-i', 's/TODO:MODNUM/' + this.options.modnum + '/g', 'doc/assigned/main.tex'])
+    this.spawnCommand('sed', ['-i', 's/TODO:MODNUM/' + this.options.modnum + '/g', 'Makefile'])
+    this.spawnCommand('sed', ['-i', 's/TODO:CHAPNUM/' + this.options.chapnum + '/g', 'Makefile'])
+    this.spawnCommand('sed', ['-i', 's/TODO:CHAPNUM/' + this.options.chapnum + '/g', 'doc/assigned/main.tex'])
     this.log('Enjoy!')
   }
 }

--- a/generators/app/templates/.vscode/settings.json
+++ b/generators/app/templates/.vscode/settings.json
@@ -4,7 +4,7 @@
   "C_Cpp.clang_format_style": "LLVM",
   "[cpp]": {
     "editor.autoIndent": true,
-    "editor.tabSize": 4,
+    "editor.tabSize": 2,
     "editor.insertSpaces": true
   },
   /* Latex */

--- a/generators/app/templates/Makefile
+++ b/generators/app/templates/Makefile
@@ -1,7 +1,7 @@
-# vim: set ts=4 sw=4 ft=sh:
-## Module TODO: Chapter TODO: Program
+# vim: set ts=2 sw=2 ft=sh:
+## Module TODO:MODNUM Chapter TODO:CHAPNUM Program
 ## Ashton S. Hellwig
-## Date: TODO:
+## Date: TODO:DATE
 ## CSC160
 ##
 
@@ -59,13 +59,13 @@ $(UDOCDIR)/%.tex: user-doc-clean
 # Debug
 ## Run
 run-debug:
-	$(DBGOUT)/ChapterTODO:-Debug.bin
+	$(DBGOUT)/ChapterTODO:CHAPNUM-Debug.bin
 ## Build
-debug: $(TGT)/debug/ChapterTODO:-DBG
+debug: $(TGT)/debug/ChapterTODO:CHAPNUM-DBG
 $(TGT)/debug/%.o: $(SRC)/%.cpp
 	$(CXX) $(CXXFLAGSDBG) -c $< -o $@
-$(TGT)/debug/ChapterTODO:-DBG: $(DBGOBJS)
-	$(CXX) $(LDFLAGS) $(DBGOBJS) -o $(DBGOUT)/ChapterTODO:-Debug.bin
+$(TGT)/debug/ChapterTODO:CHAPNUM-DBG: $(DBGOBJS)
+	$(CXX) $(LDFLAGS) $(DBGOBJS) -o $(DBGOUT)/ChapterTODO:CHAPNUM-Debug.bin
 ## Removes Object Files
 clean-dbg:
 	rm -rf $(TGT)/debug/*.o
@@ -77,13 +77,13 @@ clean-all-dbg:
 # Release
 ## Run
 run-release:
-	$(RELOUT)/ChapterTODO:-Release.bin
+	$(RELOUT)/ChapterTODO:CHAPNUM-Release.bin
 ## Build
-release: $(TGT)/release/ChapterTODO:-REL
+release: $(TGT)/release/ChapterTODO:CHAPNUM-REL
 $(TGT)/release/%.o: $(SRC)/%.cpp
 	$(CXX) $(CXXFLAGSREL) -c $< -o $@
-$(TGT)/release/ChapterTODO:-REL: $(RELOBJS)
-	$(CXX) $(LDFLAGS) $(RELOBJS) -o $(RELOUT)/ChapterTODO:-Release.bin
+$(TGT)/release/ChapterTODO:CHAPNUM-REL: $(RELOBJS)
+	$(CXX) $(LDFLAGS) $(RELOBJS) -o $(RELOUT)/ChapterTODO:CHAPNUM-Release.bin
 	cp $(UDOCDIR)/userdocs.pdf $(RELOUT)/userdocs.pdf
 ## Removes object files
 clean-rel:

--- a/generators/app/templates/doc/assigned/main.tex
+++ b/generators/app/templates/doc/assigned/main.tex
@@ -76,7 +76,7 @@
   \setlength{\floatsep}{12pt}
 
   %% Title page
-  \title{Chapter 5 Program Documentation}
+  \title{Chapter TODO:CHAPNUM Program Documentation}
   \author{Ashton Hellwig}
   \date\today
   \setcounter{tocdepth}{3}

--- a/generators/app/templates/doc/assigned/main.tex
+++ b/generators/app/templates/doc/assigned/main.tex
@@ -1,5 +1,5 @@
 %
-% Module TODO: Chapter TODO: Program Documentation
+% Module TODO:MODNUM Chapter TODO:CHAPNUM Program Documentation
 % CSC160-C00: Computer Science I (C++)
 % Author: Ashton Hellwig
 %
@@ -84,7 +84,7 @@
   %% Subsequent pages
   \lhead{CSC160}
   \rhead{Computer Science I (C++)}
-  \lfoot{MTODO:CTODO:}
+  \lfoot{MTODO:MODNUMCTODO:CHAPNUM}
   \rfoot{A. Hellwig}
 
 
@@ -177,7 +177,7 @@ All uppercase letters used were:
         \item with GNU G++
       \end{itemize}
       \subsubsection{Within Visual Studio}
-        Simply load \texttt{ChapterTODO:.sln} in Microsoft Visual Studio and 
+        Simply load \texttt{ChapterTODO:CHAPNUM.sln} in Microsoft Visual Studio and 
           build/run the \texttt{release} version. If you require debugging
           information, switch the configuration to \texttt{debug}.
       \subsubsection{Bundled Release}
@@ -186,12 +186,12 @@ All uppercase letters used were:
             \textbf{with a terminal emulator or command prompt}, this will
             (most likely) mean running:
             \begin{lstlisting}[language=bash]
-              cd %USERPROFILE%\Downloads\ChapterTODO:\x64\Release\
+              cd %USERPROFILE%\Downloads\ChapterTODO:CHAPNUM\x64\Release\
             \end{lstlisting}
           \item To run the program simply issue this within the command
             prompt
             \begin{lstlisting}[language=bash]
-              .\ChapterTODO:.exe
+              .\ChapterTODO:CHAPNUM.exe
             \end{lstlisting}
         \end{enumerate}
         Of course if preferred, you may also navigate to the release folder in


### PR DESCRIPTION
This will allow users to include arguments when calling the generator:

* modnum = Module Number
* chapnum = Chapter Number

Now, instead of just calling `yo cpp-csc`, one will need to call the generator with the module and chapter number being worked. It will be auto-inserted into `doc/assigned/main.tex` and `Makefile`. GNU `sed` is required until I find a better way to parse Latex.